### PR TITLE
attach custom error properties to the log output

### DIFF
--- a/lib/prettystream.js
+++ b/lib/prettystream.js
@@ -350,15 +350,17 @@ function PrettyStream(opts){
     }
   }
 
-  function extractCustomDetails(rec){
-    var skip = ['name', 'hostname', 'pid', 'level', 'component', 'msg', 'time', 'v', 'src', 'err', 'client_req', 'client_res', 'req', 'res'];
+  function extractCustomDetails(source, options){
+    var skip = options && options.skip ? options.skip : [];
+    var prefix = options && options.prefix ? options.prefix : '';
 
     var details = [];
     var extras = {};
 
-    Object.keys(rec).forEach(function(key) {
+    Object.keys(source).forEach(function(key) {
       if (skip.indexOf(key) === -1){
-        var value = rec[key];
+        var logKey = prefix + key;
+        var value = source[key];
         if (typeof value === 'undefined') value = '';
         var stringified = false;
         if (typeof value === 'function') {
@@ -369,11 +371,11 @@ function PrettyStream(opts){
           stringified = true;
         }
         if (value.indexOf('\n') !== -1 || value.length > 50) {
-          details.push(key + ': ' + value);
+          details.push(logKey + ': ' + value);
         } else if (!stringified && (value.indexOf(' ') != -1 ||  value.length === 0)){
-          extras[key] = JSON_stringify(value);
+          extras[logKey] = JSON_stringify(value);
         } else {
-          extras[key] = value;
+          extras[logKey] = value;
         }
       }
     });
@@ -382,6 +384,16 @@ function PrettyStream(opts){
       details: details,
       extras: extras
     };
+  }
+
+  function extractCustomRecordDetails(rec){
+    return extractCustomDetails(rec, { skip: [
+      'name', 'hostname', 'pid', 'level', 'component', 'msg', 'time', 'v', 'src', 'err', 'client_req', 'client_res', 'req', 'res'
+    ] });
+  }
+
+  function extractCustomErrorDetails(rec){
+    return extractCustomDetails(rec.err || {}, { prefix: 'err.' });
   }
 
   function applyDetails(results, details, extras){
@@ -420,7 +432,8 @@ function PrettyStream(opts){
     if (rec.client_req){ applyDetails(extractClientReqDetail(rec), details, extras); }
     if (rec.client_res){ applyDetails(extractClientResDetail(rec), details, extras); }
 
-    applyDetails(extractCustomDetails(rec), details, extras);
+    applyDetails(extractCustomRecordDetails(rec), details, extras);
+    applyDetails(extractCustomErrorDetails(rec), details, extras);
 
     extras = stylize(
       (extras.length ? ' (' + extras.join(', ') + ')' : ''), 'grey');


### PR DESCRIPTION
We usually add extra information to our error objects and this never gets logged because this module only log the error stack. These changes would add any extra (enumerable) properties you attach to an error object to the log output as `err.property_name`